### PR TITLE
Adding MODX Theme classes to the upgrade button

### DIFF
--- a/core/components/upgrademodx/elements/snippets/upgrademodxwidget.snippet.php
+++ b/core/components/upgrademodx/elements/snippets/upgrademodxwidget.snippet.php
@@ -358,7 +358,7 @@ if ($upgradeAvailable) {
         . ')';
     $placeholders['[[+ugm_form]]'] = '<br/><br/>
         <form method="post" action="">
-            <input style="padding:3px 10px;margin-left:50px;background-color:whitesmoke;"
+            <input class="x-btn x-btn-small x-btn-icon-small-left primary-button x-btn-noicon"
                    type="submit" name="UpgradeMODX" value="' . $modx->lexicon('ugm_upgrade_modx') .  '">
         </form>';
 


### PR DESCRIPTION
Before:
![modx-upgrade-before](https://cloud.githubusercontent.com/assets/114390/9569384/e6710760-4f82-11e5-9b39-0c587dc43b0e.png)

After:
![modx-upgrade-after](https://cloud.githubusercontent.com/assets/114390/9569383/e66d7988-4f82-11e5-9232-6718089a01aa.png)
