### PR TITLE
Fixing #8 Empty modx.zip file

### DIFF
--- a/core/components/upgrademodx/elements/chunks/upgrademodxsnippetscriptsource.chunk.php
+++ b/core/components/upgrademodx/elements/chunks/upgrademodxsnippetscriptsource.chunk.php
@@ -85,7 +85,8 @@ class MODXInstaller {
                 curl_setopt($ch, CURLOPT_USERAGENT, 'Mozilla/4.0 (compatible; MSIE 6.0)');
                 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
                 curl_setopt($ch, CURLOPT_FILE, $newf);
-                if (is_null(ini_get('open_basedir')) && filter_var(ini_get('safe_mode'), FILTER_VALIDATE_BOOLEAN) === false) {
+                $openBasedir = ini_get('open_basedir');
+                if (empty($openBasedir) && filter_var(ini_get('safe_mode'), FILTER_VALIDATE_BOOLEAN) === false) {
                     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
                 } else {
                     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);

--- a/core/components/upgrademodx/elements/chunks/upgrademodxsnippetscriptsource.chunk.php
+++ b/core/components/upgrademodx/elements/chunks/upgrademodxsnippetscriptsource.chunk.php
@@ -85,8 +85,6 @@ class MODXInstaller {
                 curl_setopt($ch, CURLOPT_USERAGENT, 'Mozilla/4.0 (compatible; MSIE 6.0)');
                 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
                 curl_setopt($ch, CURLOPT_FILE, $newf);
-                curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
-                curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
                 if (is_null(ini_get('open_basedir')) && filter_var(ini_get('safe_mode'), FILTER_VALIDATE_BOOLEAN) === false) {
                     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
                 } else {


### PR DESCRIPTION
I had some issues with the current code:

- The open_basedir check was somehow wrong since it could contain a string or is empty/null.
- The redirect could be done without the 301/302 check with CURLINFO_REDIRECT_URL since PHP 5.3.7. The previous redirect check did not work here.