### PR TITLE
Quick fix for the open_basedir redirect issue

### DIFF
--- a/core/components/upgrademodx/model/upgrademodx.class.php
+++ b/core/components/upgrademodx/model/upgrademodx.class.php
@@ -225,7 +225,7 @@ if (!class_exists('UpgradeMODX')) {
             foreach ($contents as $version) {
                 $name = substr($version['name'], 1);
 
-                $url = 'http://modx.com/download/direct/modx-' . $name . '.zip';
+                $url = 'https://modx.com/download/direct?id=modx-' . $name . '.zip';
                 $versionArray[$name] = array(
                     'tree' => 'Revolution',
                     'name' => 'MODX Revolution ' . htmlentities($name),


### PR DESCRIPTION
The current code of UpgradeMODX follows only one redirect, but `http://modx.com/download/direct/modx-xxx.zip` uses 3 redirects until the download from the S3 Bucket. 