### PR TITLE
Do not require Guzzle7 extra for MODX 3

### DIFF
--- a/_build/resolvers/dependencies.resolver.php
+++ b/_build/resolvers/dependencies.resolver.php
@@ -24,6 +24,10 @@ switch ($options[xPDOTransport::PACKAGE_ACTION]) {
         /**
          * Define required packages: name => minimum version
          */
+        $v = (int) $modx->getVersionData()['version'];
+        if ($v >= 3) {
+            return true;
+        }
         $packages = [
             'Guzzle7' => '1.0.0-pl',
         ];

--- a/core/components/upgrademodx/elements/snippets/upgrademodxwidget.snippet.php
+++ b/core/components/upgrademodx/elements/snippets/upgrademodxwidget.snippet.php
@@ -54,10 +54,8 @@
 /* Initialize */
 /* This will execute when in MODX */
 
-if (! class_exists('Guzzle7')) {
-    $msg = '<br/><span style="color:red">' . 'Please Install the Guzzle7 extra</span>';
-    return $msg;
-
+if (!class_exists('\GuzzleHttp\Client') && !class_exists('Guzzle7')) {
+    return '<br/><span style="color:red">' . 'Please Install the Guzzle7 extra</span>';
 }
 
 $language = $modx->getOption('ugm_language', null, $modx->getOption('manager_language'), true);


### PR DESCRIPTION
MODX 3 already has `guzzlehttp/guzzle` as composer dependency in `core/vendor` directory.

We don't need to require additional extra with different version of Guzzle.