### PR TITLE
Fix exception handling

### DIFF
--- a/core/components/upgrademodx/model/upgrademodx/upgrademodx.class.php
+++ b/core/components/upgrademodx/model/upgrademodx/upgrademodx.class.php
@@ -674,12 +674,12 @@ EOD;
 
                 //  } catch (\Exception $e) {
             } catch (RequestException $e) {
+                /** @var $e \GuzzleHttp\Exception\RequestException */
                 $msg = $this->parseException($e, $verbose);
                 echo $msg;
                 $retVal = false;
             } catch (\Exception $e) {
-                /** @var $e \GuzzleHttp\Exception\RequestException */
-                $msg = $this->parseException($e, $verbose);
+                $msg = $e->getMessage();
                 echo $msg;
                 $retVal = false;
             }


### PR DESCRIPTION
Only the first catch will be triggered explicitly by Guzzle, the second catch can be triggered by other errors. If the second error tries to get a Guzzle response, another not catched error occurs.

<img width="754" height="422" alt="image" src="https://github.com/user-attachments/assets/47965243-8cf4-4d7e-85fc-c4e05e680313" />
